### PR TITLE
add ci job to pre-build osx and Linux multi-arch

### DIFF
--- a/.github/workflows/build-npm-and-release.yml
+++ b/.github/workflows/build-npm-and-release.yml
@@ -7,6 +7,7 @@ env:
   push:
     branches:
       - main
+      - build-npm-with-ci # will need to remove before merge but just so can link to my ci running
     tags-ignore:
       - '**'
     paths-ignore:
@@ -87,8 +88,6 @@ jobs:
           docker build -f release/Dockerfile.linux -t builder .
           docker run --rm -v $(pwd):/build -w /build builder yarn --ignore-scripts 
           docker run --rm -v $(pwd):/build -w /build builder yarn build:linux
-          ls -l
-          ls -l lib
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-npm-and-release.yml
+++ b/.github/workflows/build-npm-and-release.yml
@@ -99,6 +99,12 @@ jobs:
           name: index.linux-x64-gnu.node
           path: crates/matrix-sdk-crypto-nodejs/lib/index.linux-x64-gnu.node
           if-no-files-found: error
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: napi-module.js
+          path: crates/matrix-sdk-crypto-nodejs/lib/napi-module.js
+          if-no-files-found: error
 
   x86_64-unknown-linux-musl:
     if: "!contains(github.event.head_commit.message, 'skip ci')"

--- a/.github/workflows/build-npm-and-release.yml
+++ b/.github/workflows/build-npm-and-release.yml
@@ -126,6 +126,7 @@ jobs:
       - x86_64-apple-darwin
       - aarch64-apple-darwin
       - x86_64-unknown-linux-gnu
+      - x86_64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v2
       - name: Setup node

--- a/.github/workflows/build-npm-and-release.yml
+++ b/.github/workflows/build-npm-and-release.yml
@@ -106,17 +106,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Enter folder
+      - name: Build
         run: |
-          ls -l
           cd crates/matrix-sdk-crypto-nodejs/
-          ls -l
-
-          docker pull ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
-          docker tag ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine builder
-
+          docker build -f release/Dockerfile.linux -t builder .
           docker run --rm -v $(pwd):/build -w /build builder yarn --ignore-scripts 
-          docker run --rm -v $(pwd):/build -w /build builder yarn build:linux:x64:musl
+          docker run --rm -v $(pwd):/build -w /build -e RUSTFLAGS="-C target-feature=-crt-static" builder yarn build:linux:x64:musl
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-npm-and-release.yml
+++ b/.github/workflows/build-npm-and-release.yml
@@ -142,7 +142,9 @@ jobs:
           echo "Bringing in artifacts"
           mkdir crates/matrix-sdk-crypto-nodejs/lib
           ls -l artifacts
-          mv artifacts/* crates/matrix-sdk-crypto-nodejs/lib/
+          
+          # Upload puts them inside folders so yank just the files out and move into lib folder
+          find artifacts -type f -exec mv {} crates/matrix-sdk-crypto-nodejs/lib/ \;
           
           echo "Installing npm dependencies"
           cd crates/matrix-sdk-crypto-nodejs/
@@ -152,14 +154,11 @@ jobs:
           yarn build:ts
           ls -l lib
  
+          # Probably need to change this to how ever you release
           if git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$";
           then
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             npm publish --access public
-          elif git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+";
-          then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            npm publish --tag next --access public
           else
             echo "Not a release, skipping publish"
           fi

--- a/.github/workflows/build-npm-and-release.yml
+++ b/.github/workflows/build-npm-and-release.yml
@@ -7,7 +7,6 @@ env:
   push:
     branches:
       - main
-      - build-npm-with-ci # will need to remove before merge but just so can link to my ci running
     tags-ignore:
       - '**'
     paths-ignore:

--- a/.github/workflows/build-npm-and-release.yml
+++ b/.github/workflows/build-npm-and-release.yml
@@ -1,0 +1,174 @@
+name: Build NPM Package
+env:
+  DEBUG: napi:*
+  APP_NAME: package-template
+  MACOSX_DEPLOYMENT_TARGET: '10.13'
+'on':
+  push:
+    branches:
+      - main
+    tags-ignore:
+      - '**'
+    paths-ignore:
+      - '**/*.md'
+      - LICENSE
+      - '**/*.gitignore'
+      - .editorconfig
+      - docs/**
+  pull_request: null
+jobs:
+  x86_64-apple-darwin:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+          toolchain: stable
+          target: x86_64-apple-darwin
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          #check-latest: true
+          #cache: yarn
+          architecture: x64
+      - name: Build
+        run: |
+          cd crates/matrix-sdk-crypto-nodejs/
+          yarn --ignore-scripts
+          yarn build:darwin:x64
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: index.darwin-x64.node
+          path: crates/matrix-sdk-crypto-nodejs/lib/index.darwin-x64.node
+          if-no-files-found: error
+  aarch64-apple-darwin:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+          toolchain: stable
+          target: aarch64-apple-darwin
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          architecture: x64
+      - name: Build
+        run: |
+          cd crates/matrix-sdk-crypto-nodejs/
+          yarn --ignore-scripts
+          yarn build:darwin:aarch64
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: index.darwin-arm64.node
+          path: crates/matrix-sdk-crypto-nodejs/lib/index.darwin-arm64.node
+          if-no-files-found: error
+
+  x86_64-unknown-linux-gnu:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd crates/matrix-sdk-crypto-nodejs/
+          docker build -f release/Dockerfile.linux -t builder .
+          docker run --rm -v $(pwd):/build -w /build builder yarn --ignore-scripts 
+          docker run --rm -v $(pwd):/build -w /build builder yarn build:linux
+          ls -l
+          ls -l lib
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: index.linux-ia32-gnu.node
+          path: crates/matrix-sdk-crypto-nodejs/lib/index.linux-ia32-gnu.node
+          if-no-files-found: error
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: index.linux-x64-gnu.node
+          path: crates/matrix-sdk-crypto-nodejs/lib/index.linux-x64-gnu.node
+          if-no-files-found: error
+
+  x86_64-unknown-linux-musl:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Enter folder
+        run: |
+          ls -l
+          cd crates/matrix-sdk-crypto-nodejs/
+          ls -l
+
+          docker pull ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+          docker tag ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine builder
+
+          docker run --rm -v $(pwd):/build -w /build builder yarn --ignore-scripts 
+          docker run --rm -v $(pwd):/build -w /build builder yarn build:linux:x64:musl
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: index.linux-x64-musl.node
+          path: crates/matrix-sdk-crypto-nodejs/lib/index.linux-x64-musl.node
+          if-no-files-found: error
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs:
+      - x86_64-apple-darwin
+      - aarch64-apple-darwin
+      - x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          check-latest: true
+      - name: Download all artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+      - name: Make npm package
+        run: |
+          echo "Bringing in artifacts"
+          mkdir crates/matrix-sdk-crypto-nodejs/lib
+          ls -l artifacts
+          mv artifacts/* crates/matrix-sdk-crypto-nodejs/lib/
+          
+          echo "Installing npm dependencies"
+          cd crates/matrix-sdk-crypto-nodejs/
+          yarn install --ignore-scripts --frozen-lockfile --registry https://registry.npmjs.org --network-timeout 300000
+          
+          echo "Compiling ts to js for releasing"
+          yarn build:ts
+          ls -l lib
+ 
+          if git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$";
+          then
+            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+            npm publish --access public
+          elif git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+";
+          then
+            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+            npm publish --tag next --access public
+          else
+            echo "Not a release, skipping publish"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/crates/matrix-sdk-crypto-nodejs/package.json
+++ b/crates/matrix-sdk-crypto-nodejs/package.json
@@ -36,7 +36,7 @@
     "build:debug": "yarn build:types && napi build --js ./lib/napi-module.js --dts napi-module.d.ts ./lib",
     "build:ts": "tsc",
     "build:test": "napi build",
-    "prepublishOnly": "yarn build:ts && ./prepare-release.sh",
+    "prepublishOnly": "yarn build:ts",
     "postinstall": "node check-exists.js"
   },
   "dependencies": {

--- a/crates/matrix-sdk-crypto-nodejs/package.json
+++ b/crates/matrix-sdk-crypto-nodejs/package.json
@@ -20,15 +20,17 @@
     "yarn.lock"
   ],
   "scripts": {
-    "rust:targets": "rustup target add x86_64-pc-windows-msvc i686-pc-windows-msvc x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-apple-darwin",
+    "rust:targets": "rustup target add x86_64-pc-windows-msvc i686-pc-windows-msvc x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl x86_64-apple-darwin aarch64-apple-darwin",
     "build:win": "yarn build:win:x64 && yarn build:win:ia32",
     "build:win:x64": "napi build --js ./lib/napi-module.js --dts napi-module.d.ts --release --platform --target x86_64-pc-windows-msvc ./lib",
     "build:win:ia32": "napi build --js ./lib/napi-module.js --dts napi-module.d.ts --release --platform --target i686-pc-windows-msvc ./lib",
     "build:linux": "yarn build:linux:x64 && yarn build:linux:ia32",
     "build:linux:x64": "napi build --js ./lib/napi-module.js --dts napi-module.d.ts --release --platform --target x86_64-unknown-linux-gnu ./lib",
+    "build:linux:x64:musl": "napi build --js ./lib/napi-module.js --dts napi-module.d.ts --release --platform --target x86_64-unknown-linux-musl ./lib",
     "build:linux:ia32": "napi build --js ./lib/napi-module.js --dts napi-module.d.ts --release --platform --target i686-unknown-linux-gnu ./lib",
     "build:darwin": "yarn build:darwin:x64",
     "build:darwin:x64": "napi build --js ./lib/napi-module.js --dts napi-module.d.ts --release --platform --target x86_64-apple-darwin ./lib",
+    "build:darwin:aarch64": "napi build --js ./lib/napi-module.js --dts napi-module.d.ts --release --platform --target aarch64-apple-darwin ./lib",
     "build:types": "napi build --js ./lib/napi-module.js --dts napi-module.d.ts --platform ./lib",
     "build:release": "yarn build:types && napi build --release ./lib",
     "build:debug": "yarn build:types && napi build --js ./lib/napi-module.js --dts napi-module.d.ts ./lib",

--- a/crates/matrix-sdk-crypto-nodejs/release/Dockerfile.linux
+++ b/crates/matrix-sdk-crypto-nodejs/release/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/crates/matrix-sdk-crypto-nodejs/release/Dockerfile.linux
+++ b/crates/matrix-sdk-crypto-nodejs/release/Dockerfile.linux
@@ -12,6 +12,10 @@ RUN apt-get install -y gcc-multilib
 RUN apt-get install -y g++-multilib
 RUN apt-get install -y cmake
 
+# This funky little hack allows compiling musl - thanks to: https://github.com/emk/rust-musl-builder/issues/53
+RUN ln /usr/bin/gcc /usr/bin/musl-gcc
+RUN ln /usr/bin/g++ /usr/bin/musl-g++
+
 # Install misc dependencies last to cache the expensive gcc layers
 RUN apt-get install -y curl
 


### PR DESCRIPTION
Closes #3 

I have a failing job included for musl - needed to compile on alpine. 

I'm going to keep battling a bit.. might be a lost cause.

But this will compile both x64 and arm64 for osx as well as i686 and x64 for linux and given credentials can ship to npm registry automatically.

Example of the CI running: https://github.com/geekgonecrazy/matrix-rust-sdk-bindings/actions/runs/2222780302